### PR TITLE
Minor version update

### DIFF
--- a/perf/round_trip.py
+++ b/perf/round_trip.py
@@ -3,22 +3,16 @@ from pyremotedata.config import remove_config
 import time
 
 def perf_roundtrip():
+    with ImplicitMount() as mount:
+        mount.ls()
+        mount.execute_command("cls")
 
-    mount = ImplicitMount()
-    mount.mount()
-    
-    mount.ls()
+        start = time.time()
+        print(mount.execute_command("recls"))
+        end = time.time()
 
-    mount.execute_command("cls")
+        print("Time taken: {} seconds".format(end-start))
 
-    start = time.time()
-    print(mount.execute_command("recls"))
-    end = time.time()
-
-    print("Time taken: {} seconds".format(end-start))
-
-    mount.unmount()
-
-
-perf_roundtrip()
-remove_config()
+if __name__ == "__main__":
+    perf_roundtrip()
+    remove_config()

--- a/perf/upload_download.py
+++ b/perf/upload_download.py
@@ -3,7 +3,7 @@ import time
 import tempfile
 import os
 
-test_size = 10**6
+test_size = 3 * 10**6
     
 def make_mock_file(dir, size):
     with tempfile.NamedTemporaryFile(dir=dir, delete=False, suffix=".txt") as f:
@@ -12,7 +12,8 @@ def make_mock_file(dir, size):
 
 def perf_test(share_link_id : str | None):
     with tempfile.TemporaryDirectory() as upload_dir, tempfile.TemporaryDirectory() as download_dir:
-        mock_files = [make_mock_file(upload_dir, test_size) for _ in range(16)]
+        mock_files = [make_mock_file(upload_dir, test_size) for _ in range(32)]
+        total_data = test_size * len(mock_files)
 
         with IOHandler(user=share_link_id, password=share_link_id, verbose=True) as io:
             if not io.exists("testing", "directory"):
@@ -36,8 +37,8 @@ def perf_test(share_link_id : str | None):
         upload_time = end_upload - start_upload
         download_time = end_download - start_download
         delete_time = end_delete - start_delete
-
-        upload_speed, download_speed, delete_speed = test_size/upload_time, test_size/download_time, test_size/delete_time
+        
+        upload_speed, download_speed, delete_speed = total_data/upload_time, total_data/download_time, total_data/delete_time
 
         print("Upload speed: {} MB/s".format(upload_speed/10**6))
         print("Download speed: {} MB/s".format(download_speed/10**6))

--- a/perf/upload_download.py
+++ b/perf/upload_download.py
@@ -3,56 +3,52 @@ import time
 import tempfile
 import os
 
-test_size = 10**9
+test_size = 10**6
+    
+def make_mock_file(dir, size):
+    with tempfile.NamedTemporaryFile(dir=dir, delete=False, suffix=".txt") as f:
+        f.write(os.urandom(size))
+        return f.name
 
-def get_mock_file(dir, size):
-    """
-    Creates a mock file of size `size` (bytes) in directory `dir`
-    At the moment the function merely assumes that the file "sample.txt" exists in the directory of this script.
-    it can be created with "openssl rand -out sample.txt -base64 $(( 2**30 * 3/4 ))" (takes a couple of seconds)
-    """
-    return "sample.txt"
+def perf_test(share_link_id : str | None):
+    with tempfile.TemporaryDirectory() as upload_dir, tempfile.TemporaryDirectory() as download_dir:
+        mock_files = [make_mock_file(upload_dir, test_size) for _ in range(16)]
 
-def perf_test():
-    upload_dir_obj = tempfile.TemporaryDirectory()
-    download_dir_obj = tempfile.TemporaryDirectory()
+        with IOHandler(user=share_link_id, password=share_link_id, verbose=True) as io:
+            if not io.exists("testing", "directory"):
+                io.execute_command("mkdir testing")
+            io.cd("testing")
+            # Set the local working directory to the directory which contains this script
+            io.lcd(os.path.dirname(os.path.abspath(__file__)))
 
-    upload_dir = upload_dir_obj.name
-    download_dir = download_dir_obj.name
+            start_upload = time.time()
+            io.upload(upload_dir, os.path.split(upload_dir)[-1])
+            end_upload = time.time()
 
-    mock_file = get_mock_file(upload_dir, size=test_size)
+            start_download = time.time()
+            io.download(os.path.split(upload_dir)[-1], download_dir)
+            end_download = time.time()
 
-    mount = ImplicitMount()
-    mount.mount()
-    mount.cd("testing")
-    # Set the local working directory to the directory which contains this script
-    mount.lcd(os.path.dirname(os.path.abspath(__file__)))
+            start_delete = time.time()
+            io.rm(os.path.split(upload_dir)[-1], force=True)
+            end_delete = time.time()
 
-    start_upload = time.time()
-    mount.put(mock_file)
-    end_upload = time.time()
+        upload_time = end_upload - start_upload
+        download_time = end_download - start_download
+        delete_time = end_delete - start_delete
 
-    start_download = time.time()
-    mount.pget(mock_file, download_dir)
-    end_download = time.time()
+        upload_speed, download_speed, delete_speed = test_size/upload_time, test_size/download_time, test_size/delete_time
 
-    start_delete = time.time()
-    mount.execute_command("rm {}".format(mock_file))
-    end_delete = time.time()
+        print("Upload speed: {} MB/s".format(upload_speed/10**6))
+        print("Download speed: {} MB/s".format(download_speed/10**6))
+        print("Delete speed: {} MB/s".format(delete_speed/10**6))
 
-    upload_time = end_upload - start_upload
-    download_time = end_download - start_download
-    delete_time = end_delete - start_delete
-
-    upload_speed, download_speed, delete_speed = test_size/upload_time, test_size/download_time, test_size/delete_time
-
-    print("Upload speed: {} MB/s".format(upload_speed/10**6))
-    print("Download speed: {} MB/s".format(download_speed/10**6))
-    print("Delete speed: {} MB/s".format(delete_speed/10**6))
-
-    mount.unmount()
-
-    upload_dir_obj.cleanup()
-    download_dir_obj.cleanup()
-
-perf_test()
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser("perf_updown")
+    parser.add_argument(
+        "-I", "--ID", type=str, required=False,
+        help="ERDA Share link ID for SSH-less testing"
+    )
+    args = parser.parse_args()
+    perf_test(args.ID)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = [
 
 [project]
 name = "pyremotedata"
-version = "0.0.76"
+version = "0.1.0"
 authors = [
   { name="Asger Svenning", email="asgersvenning@gmail.com" },
 ]

--- a/src/pyremotedata/config.py
+++ b/src/pyremotedata/config.py
@@ -19,6 +19,16 @@ def ask_user(question: str, interactive: bool = True) -> str:
         raise RuntimeError("Cannot ask user for input when interactive=False: " + question)
     return input(question)
 
+def escape_str(s):
+    if not isinstance(s, str):
+        return s
+    if s[0] == "'" and s[-1] == "'":
+        return s
+    if s[0] == '"' and s[-1] == '"':
+        return s
+    return f'"{s}"'
+    
+
 ENVIRONMENT_VARIABLES = (
     "PYREMOTEDATA_REMOTE_USERNAME", 
     "PYREMOTEDATA_REMOTE_URI", 
@@ -53,6 +63,45 @@ def remove_config() -> None:
     else:
         module_logger.info("No config file found at {}".format(CONFIG_PATH))
 
+DEFAULT_LFTP_CONFIG = {
+    'mirror:use-pget-n': 5, # Enable this to split a single file into multiple chunks and download them in parallel, when using mirror
+    'net:limit-rate': 0,  # No limit on transfer rate, maximizing throughput.
+    'xfer:parallel': 5,  # Enable this to split a single file into multiple chunks and download them in parallel
+    'mirror:parallel-directories': "on",  # Enable this to download multiple directories in parallel
+    'ftp:sync-mode': 'off',  # Enable this to disable synchronization mode, which is used to prevent data corruption when downloading multiple files in parallel
+    'cmd:parallel': 1,  # If you write bespoke scripts that execute multiple commands in parallel, you can increase this value.
+    'net:connection-limit': 0,  # No limit on connections, maximizing throughput.
+    'cmd:verify-path': "on",  # To reduce latency, we skip path verification.
+    'cmd:verify-host': "on",  # For initial security, it's good to verify the host.
+    'sftp:auto-confirm': "yes", # Automatically accept fingerprint
+    'sftp:size-read': 0x5000,  # Increased block size for better read throughput.
+    'sftp:size-write': 0x5000,  # Increased block size for better write throughput.
+    'sftp:max-packets-in-flight' : 512,  # Increased number of packets in flight for better throughput.
+    'xfer:verify': "off",  # Disabling this for maximum speed.
+    'cmd:interactive': "false",  # Disabled for automated transfers.
+    'cmd:trace': "false",  # Disabled unless debugging is required.
+    'xfer:clobber': "true",  # Overwrite existing files.
+}
+LFTP_CONFIG_COMMENTS = {
+    'mirror:use-pget-n': "Enable this to split a single file into multiple chunks and download them in parallel, when using mirror",
+    'net:limit-rate': "No limit on transfer rate, maximizing throughput.",
+    'xfer:parallel': "Enable this to split a single file into multiple chunks and download them in parallel",
+    'mirror:parallel-directories': "Enable this to download multiple directories in parallel",
+    'ftp:sync-mode': "Enable this to disable synchronization mode, which is used to prevent data corruption when downloading multiple files in parallel",
+    'cmd:parallel': "If you write bespoke scripts that execute multiple commands in parallel, you can increase this value.",
+    'net:connection-limit': "No limit on connections, maximizing throughput.",
+    'cmd:verify-path': "To reduce latency, we skip path verification.",
+    'cmd:verify-host': "For initial security, it's good to verify the host.",
+    'sftp:auto-confirm': "Automatically accept fingerprint",
+    'sftp:size-read': "Increased block size for better read throughput.",
+    'sftp:size-write': "Increased block size for better write throughput.",
+    'sftp:max-packets-in-flight' : "Increased number of packets in flight for better throughput.",
+    'xfer:verify': "Disabling this for maximum speed.",
+    'cmd:interactive': "Disabled for automated transfers.",
+    'cmd:trace': "Disabled unless debugging is required.",
+    'xfer:clobber': "Overwrite existing files."
+}
+
 def create_default_config(interactive: bool = True) -> None:
     """Create a default YAML configuration file.
 
@@ -77,22 +126,7 @@ implicit_mount:
 
     # Lftp configuration (Can be left as-is)
     lftp:
-        'mirror:use-pget-n': 5  # Enable this to split a single file into multiple chunks and download them in parallel, when using mirror
-        'net:limit-rate': 0  # No limit on transfer rate, maximizing throughput.
-        'xfer:parallel': 5  # Enable this to split a single file into multiple chunks and download them in parallel
-        'mirror:parallel-directories': "on"  # Enable this to download multiple directories in parallel
-        'ftp:sync-mode': 'off'  # Enable this to disable synchronization mode, which is used to prevent data corruption when downloading multiple files in parallel
-        'cmd:parallel': 1  # If you write bespoke scripts that execute multiple commands in parallel, you can increase this value.
-        'net:connection-limit': 0  # No limit on connections, maximizing throughput.
-        'cmd:verify-path': "on"  # To reduce latency, we skip path verification.
-        'cmd:verify-host': "on"  # For initial security, it's good to verify the host.
-        'sftp:size-read': 0x5000  # Increased block size for better read throughput.
-        'sftp:size-write': 0x5000  # Increased block size for better write throughput.
-        'sftp:max-packets-in-flight' : 512  # Increased number of packets in flight for better throughput.
-        'xfer:verify': "off"  # Disabling this for maximum speed.
-        'cmd:interactive': "false"  # Disabled for automated transfers.
-        'cmd:trace': "false"  # Disabled unless debugging is required.
-        'xfer:clobber': "true"  # Overwrite existing files.
+        {"      ".join([f"'{k}': {escape_str(v)} # {LFTP_CONFIG_COMMENTS.get(k, '')}" for k, v in DEFAULT_LFTP_CONFIG.items()])}
 
 """
     
@@ -117,7 +151,7 @@ def get_config(validate: bool = True) -> dict | None:
         fails.
     """
     if not os.path.exists(CONFIG_PATH):
-        interactive = os.getenv("PYREMOTEDATA_AUTO", "yes").lower().strip() != "yes"
+        interactive = os.getenv("PYREMOTEDATA_AUTO", "no").lower().strip() != "yes"
         if not interactive or ask_user("Config file not found. Create default config file? (y/n): ", interactive).lower().strip() == 'y':
             create_default_config(interactive)
         else:
@@ -216,3 +250,5 @@ def deparse_args(config: dict, what: str) -> str:
     
     return arg_str
 
+if __name__ == "__main__":
+    create_default_config(interactive=True)

--- a/src/pyremotedata/config.py
+++ b/src/pyremotedata/config.py
@@ -64,7 +64,7 @@ def remove_config() -> None:
         module_logger.info("No config file found at {}".format(CONFIG_PATH))
 
 DEFAULT_LFTP_CONFIG = {
-    'mirror:use-pget-n': 5, # Enable this to split a single file into multiple chunks and download them in parallel, when using mirror
+    # 'mirror:use-pget-n': 1, # Enable this to split a single file into multiple chunks and download them in parallel, when using mirror
     'net:limit-rate': 0,  # No limit on transfer rate, maximizing throughput.
     'xfer:parallel': 5,  # Enable this to split a single file into multiple chunks and download them in parallel
     'mirror:parallel-directories': "on",  # Enable this to download multiple directories in parallel
@@ -83,7 +83,7 @@ DEFAULT_LFTP_CONFIG = {
     'xfer:clobber': "true",  # Overwrite existing files.
 }
 LFTP_CONFIG_COMMENTS = {
-    'mirror:use-pget-n': "Enable this to split a single file into multiple chunks and download them in parallel, when using mirror",
+    # 'mirror:use-pget-n': "Enable this to split a single file into multiple chunks and download them in parallel, when using mirror",
     'net:limit-rate': "No limit on transfer rate, maximizing throughput.",
     'xfer:parallel': "Enable this to split a single file into multiple chunks and download them in parallel",
     'mirror:parallel-directories': "Enable this to download multiple directories in parallel",

--- a/src/pyremotedata/implicit_mount.py
+++ b/src/pyremotedata/implicit_mount.py
@@ -848,7 +848,7 @@ class ImplicitMount:
             return retval
         if not isinstance(retval, list):
             raise RuntimeError(f'Unexpected return value: {retval}')
-        return dict(line.split("\t")[::-1] for line in retval)
+        return dict((size_path[1], int(size_path[0])) for line in retval if (size_path := line.split("\t")))
 
     def ls(
             self, 

--- a/src/pyremotedata/implicit_mount.py
+++ b/src/pyremotedata/implicit_mount.py
@@ -21,12 +21,14 @@ import tempfile
 import threading
 import time
 import uuid
+from enum import Enum
 from queue import Queue
 from random import choices, shuffle
+
 from tqdm.auto import trange
 
 from pyremotedata import CLEAR_LINE, ESC_EOL, main_logger
-from pyremotedata.config import get_implicit_mount_config
+from pyremotedata.config import DEFAULT_LFTP_CONFIG, get_implicit_mount_config
 
 BENIGN_ERR = re.compile("(wait|fg): no current job")
 
@@ -70,6 +72,23 @@ def _unlink(p : str, force : bool) -> None:
         os.chmod(p, stat.S_IWUSR)
         os.unlink(p)
 
+class RemoteType(int, Enum):
+    MISSING = 0
+    FILE = 1
+    DIRECTORY = 2
+    @classmethod
+    def _missing_(cls, value):
+        if value is None:
+            return cls.NONE
+        if isinstance(value, str):
+            name = value.strip().upper()
+            try:
+                return cls[name]
+            except KeyError:
+                raise ValueError(f'Only remote modes "MISSING", "FILE" and "DIRECTORY" are defined, not {value!r}.')
+        # let IntEnum's default handling raise for bad ints:
+        return super()._missing_(value)
+
 class ImplicitMount:
     """
     This is a low-level wrapper of LFTP, which provides a pythonic interface for executing LFTP commands and reading the output.
@@ -81,7 +100,7 @@ class ImplicitMount:
     Args:
         user: The username to use for connecting to the remote directory.
         password: The *SFTP* password to possibly use when connecting to the remote host.
-        remote: The remote server to connect to.
+        remote: The remote server to connect to. If `user` and `password` are supplied, this will default to 'io.erda.au.dk' for convenience.
         port: The port to connect to (default: 2222).
         verbose: If True, print the commands executed by the class.
 
@@ -115,7 +134,19 @@ class ImplicitMount:
             verbose : bool=main_logger.isEnabledFor(logging.DEBUG)
         ):
         # Default argument configuration and type checking
-        self.default_config = get_implicit_mount_config(validate=(isinstance(user, str) and isinstance(remote, str)))
+        if not (user is None or password is None or port is None):
+            if remote is None:
+                # Since 99.9% of use-cases are for ERDA at the moment, the decrease in friction this 
+                # default adds is worth the non-generality (may be changed in the future)
+                main_logger.info("Defaulting to 'io.erda.au.dk' because user and password have been manually passed!")
+            self.default_config = {
+                "default_remote_dir" : "/",
+                "local_dir" : None,
+                "remote" : "io.erda.au.dk",
+                "lftp": DEFAULT_LFTP_CONFIG.copy()
+            }
+        else:
+            self.default_config = get_implicit_mount_config(validate=(isinstance(user, str) and isinstance(remote, str)))
         if user is None:
             user = self.default_config['user']
         if remote is None:
@@ -321,7 +352,11 @@ class ImplicitMount:
         formatted_args = self.format_options(**args)
 
         # Combine command and arguments
-        full_command = f"{command} {formatted_args}" if formatted_args else command
+        if " " in command:
+            cmd, other = command.split(" ", 1)
+        else:
+            cmd, other = command, ""
+        full_command = f"{cmd} {formatted_args} {other}" if formatted_args else command
         if output:
             if uuid_str is None:
                 uuid_str = str(uuid.uuid4())
@@ -350,9 +385,15 @@ class ImplicitMount:
             Exception: If the subprocess fails to start.
             RuntimeError: If the connection to the remote directory fails.
         """
-        # set mirror:use-pget-n 5;set net:limit-rate 0;set xfer:parallel 5;set mirror:parallel-directories true;set ftp:sync-mode off;"
         # Merge default settings and user settings. User settings will override default settings.
         lftp_settings = {**self.default_config['lftp'], **lftp_settings} if lftp_settings is not None else self.default_config['lftp']
+        
+        # Password connect:
+        if isinstance(self.password, str) and len(self.password) > 0 and self.password != "":
+            if "sftp:connect-program" in lftp_settings:
+                raise KeyError(f"LFTP setting 'sftp:connect-program' cannot be used with password connection!")
+            lftp_settings["sftp:connect-program"] = "ssh -a -x -o PreferredAuthentications=password -o PubkeyAuthentication=no"
+
         # Format settings
         lftp_settings_str = ""
         for key, value in lftp_settings.items():
@@ -433,6 +474,166 @@ class ImplicitMount:
         self.lftp_shell.stderr.close()
         self.lftp_shell = None
 
+    def exists(
+        self,
+        path : str,
+        mode : str="any",
+        execute : bool=True,
+        **kwargs
+        ):
+        """
+        Check if a path (file/directory/link) exists.
+
+        Args:
+            path: Path to check.
+            mode: Which types of file to match. Not-case sensitive, 
+                currently "any" (default), "file" and "directory" are supported.
+            **kwargs: Additional arguments passed to execute_command.
+        
+        Returns:
+            Boolean if `execute=True` else the command.
+        """
+        if not isinstance(mode, str):
+            raise TypeError(f'Unexpected exist type: {type(mode)}')
+        mode = mode.strip().lower()
+        # Some paths are "base-cases" that should exist in all cases:
+        # - Current directory
+        # - Parent directory of current directory
+        # - Root directory
+        if path in [".", "..", "/", "/.", "./"]:
+            if not execute:
+                return "NO CMD"
+            return mode in ["any", "directory"]
+        parts = path.split("/")
+        # Recursively check if the parent directories exist to avoid error in glob expansion
+        if len(parts) > 1:
+            if not self.exists("/".join(parts[:-1]), mode="directory"):
+                return False
+        else:
+            parts.insert(0, ".")
+        # Get glob mode-argument
+        match mode:
+            case "any":
+                type_arg = "-a"
+            case "file":
+                type_arg = "-f"
+            case "directory":
+                type_arg = "-d"
+        # Check if file is hidden, needs special handling: https://en.wikipedia.org/wiki/Glob_(programming)#Origin
+        hidden = parts[-1].startswith(".")
+        exist_glob = f'{"/".join(parts[:-1])}/{"." if hidden else ""}*{parts[-1].removeprefix(".")}'
+        glob_result = self.execute_command(f'glob {type_arg} --exist "{exist_glob}" && echo "YES" || echo "NO"')
+        if not execute:
+            return glob_result
+        if isinstance(glob_result, list) and len(glob_result) == 1:
+            glob_result = glob_result[0]
+        else:
+            raise RuntimeError(f'Unexpected return value: {glob_result}')
+        return glob_result == "YES"
+    
+    def pathtype(
+        self,
+        remote_path : str
+        ):
+        if not self.exists(remote_path, mode="any"):
+            return RemoteType.MISSING
+        if self.exists(remote_path, mode="directory"):
+            return RemoteType.DIRECTORY
+        if self.exists(remote_path, mode="file"):
+            return RemoteType.FILE
+        raise RuntimeError(f'Unknown remote path type "{remote_path}" exists, but is not a file or directory?')
+
+    def get(
+            self,
+            remote_path : str | list[str] | tuple[str, ...],
+            local_path : str | list[str] | tuple[str, ...] | None=None,
+            execute : bool=True,
+            **kwargs
+        ):
+        """Download file(s) using LFTP ``get``.
+
+        Args:
+            remote_path: Remote file path to download.
+            local_path: Local download destination path. If
+                None, downloads to the current local directory.
+            blocking: If True, wait for completion.
+            execute: If False, return the command string.
+            output: If True, return absolute remote path(s).
+            **kwargs: Additional options forwarded to ``put``.
+
+        Returns:
+            Command string(s) when ``execute`` is False; otherwise, local destination path(s) based on the type of `remote_path`.
+        """
+        rettype = type(remote_path)
+        if not isinstance(remote_path, (str, list, tuple)):
+            raise TypeError(f'Invalid download path type: {type(remote_path)}')
+        if isinstance(remote_path, str):
+            remote_path = [remote_path]
+        if local_path is None:
+            local_path = [os.path.basename(rp) for rp in remote_path]
+        elif isinstance(local_path, str):
+            local_path = [local_path]
+        if len(remote_path) != len(local_path):
+            raise ValueError(f'Number of local paths (destination) must match number of remote paths (source), but: {len(remote_path)=} & {len(local_path)=}')
+        if len(remote_path) == 0:
+            return rettype()
+        if len(remote_path) > 1:
+            retorder = {rp : None for rp in remote_path}
+            cmds = []
+            local_destination_dirs = ["/".join(lp.split("/")[:-1]) or "." for lp in local_path]
+            for local_destination_dir in set(local_destination_dirs):
+                dir_remote_paths = [rp for rp, ldd in zip(remote_path, local_destination_dirs) if ldd == local_destination_dir]
+                dir_retval = self.mget(dir_remote_paths, local_destination_dir=local_destination_dir, execute=execute, **kwargs)
+                if not execute:
+                    cmds.append(dir_retval)
+                    continue
+                for rv, rp in zip(dir_retval, dir_remote_paths):
+                    retorder[rp] = rv
+            if not execute:
+                return cmds
+            retval = [retorder[rp] for rp in remote_path]
+            return rettype(retval)
+        kwargs.pop("P", None)
+        remote_path, local_path = remote_path[0], local_path[0]
+        exec_output = self.execute_command(
+            # f"get " + " ".join(f'{rp} -o {lp}' for rp, lp in zip(remote_path, local_path)),
+            f'get "{remote_path}" -o "{local_path}"',
+            execute=execute,
+            **kwargs
+        )
+        if not execute:
+            return exec_output
+        lpwd = self.lpwd()
+        retval = [f'{lpwd}/{lp}' for lp in local_path]
+        if rettype == str:
+            if not len(retval) == 1:
+                raise RuntimeError(f'Expected one local destination, but got {len(retval)} instead.')
+            return retval[0]
+        return rettype(retval)
+    
+    def mget(
+        self,
+        remote_paths : list[str] | tuple[str, ...],
+        local_destination_dir : str,
+        execute : bool=True,
+        default_args : dict | None=None,
+        **kwargs
+        ):
+        default_args = default_args or {}
+        default_args = {"P" : 5, **default_args}
+        exec_output = self.execute_command(
+            "mget " + " ".join([f'"{rp}"' for rp in remote_paths]),
+            execute=execute,
+            default_args=default_args,
+            O=local_destination_dir,
+            **kwargs
+        )
+        if not execute:
+            return exec_output
+        lpwd = self.lpwd()
+        return [f'{lpwd}/{os.path.basename(rp)}' for rp in remote_paths]
+        
+
     def pget(
             self, 
             remote_path : str, 
@@ -440,6 +641,7 @@ class ImplicitMount:
             blocking : bool=True,
             execute : bool=True,
             output : bool | None=None, 
+            default_args : dict | None=None,
             **kwargs
         ) -> str | None:
         """Download a single file using LFTP ``pget``.
@@ -466,17 +668,19 @@ class ImplicitMount:
             while os.path.exists(subdir := os.path.join(local_destination, str(uuid.uuid4()))):
                 pass
             os.makedirs(subdir)
-            return self.pget(remote_path=remote_path, local_destination=subdir, blocking=blocking, execute=execute, output=output, **kwargs)
+            return self.pget(remote_path=remote_path, local_destination=subdir, blocking=blocking, execute=execute, output=output, default_args=default_args, **kwargs)
+        
+        default_args = default_args or {}
+        default_args = {"n" : 5, **default_args}
 
-        default_args = {'n': 5}
-        args = {**default_args, **kwargs}
-        formatted_args = self.format_options(**args)
-        full_command = f'pget {formatted_args} "{remote_path}" -o "{local_destination}"'
+        full_command = f'pget "{remote_path}" -o "{local_destination}"'
         exec_output = self.execute_command(
             full_command, 
             output=output, 
             blocking=blocking,
-            execute=execute
+            execute=execute,
+            default_args=default_args,
+            **kwargs
         )
         if not execute:
             return exec_output
@@ -485,18 +689,16 @@ class ImplicitMount:
     
     def put(
             self,
-            local_path : str,
-            remote_destination : str | None=None,
-            blocking : bool=True,
+            local_path : str | list[str] | tuple[str, ...],
+            remote_path : str | list[str] | tuple[str, ...] | None=None,
             execute : bool=True,
-            output : bool | None=None,
             **kwargs
         ):
         """Upload file(s) using LFTP ``put``.
 
         Args:
-            local_path: Local file path to upload.
-            remote_destination: Remote destination path. If
+            local_path: Local file(s) to upload.
+            remote_path: Remote file path(s) to upload to. If
                 None, uploads to the current remote directory.
             blocking: If True, wait for completion.
             execute: If False, return the command string.
@@ -504,51 +706,142 @@ class ImplicitMount:
             **kwargs: Additional options forwarded to ``put``.
 
         Returns:
-            Command string when ``execute`` is False; otherwise, list of
-            absolute remote paths of the uploaded file(s).
+            Command string(s) when ``execute`` is False; otherwise, remote destination path(s) based on the type of `remote_path`.
         """
-        def source_destination(local_path: str | list[str], remote_destination: str | list[str] | None=None):
-            if isinstance(local_path, str):
-                local_path = [local_path]
-            if not isinstance(local_path, list):
-                raise TypeError("Expected list or str, got {}".format(type(local_path)))
-            if remote_destination is None:
-                if isinstance(local_path, list):
-                    remote_destination = [os.path.basename(p) for p in local_path]
-                elif isinstance(local_path, str):
-                    remote_destination = os.path.basename(local_path)
-                else:
-                    raise TypeError("Expected list or str, got {}".format(type(local_path)))
-            elif isinstance(remote_destination, str):
-                remote_destination = [remote_destination]
-            if not isinstance(remote_destination, list):
-                raise TypeError("Expected list or str, got {}".format(type(remote_destination)))
-            if len(local_path) != len(remote_destination):
-                raise ValueError("Expected local_path and remote_destination to have the same length, got {} and {} instead.".format(len(local_path), len(remote_destination)))
-            return remote_destination, " ".join([f'"{l}" -o "{r}""'for l, r in zip(local_path, remote_destination)])
-        
-        if output is None:
-            output = blocking
-        # OBS: The online manual for LFTP is invalid for put (at least on ERDA); the included "P" option for the put command does not exist
-        default_args = {}
-        args = {**default_args, **kwargs}
-        formatted_args = self.format_options(**args)
-        remote_destination, src_to_dst = source_destination(local_path, remote_destination)
-        full_command = f"put {formatted_args} {src_to_dst}"
+        rettype = type(local_path)
+        if not isinstance(local_path, (str, list, tuple)):
+            raise TypeError(f'Invalid upload path type: {type(local_path)}')
+        if isinstance(local_path, str):
+            local_path = [local_path]
+        if remote_path is None:
+            remote_path = [os.path.basename(lp) for lp in local_path]
+        elif isinstance(remote_path, str):
+            remote_path = [remote_path]
+        if len(remote_path) != len(local_path):
+            raise ValueError(f'Number of local paths (destination) must match number of remote paths (source), but: {len(remote_path)=} & {len(local_path)=}')
+        if len(local_path) == 0:
+            return rettype()
+        if len(local_path) > 1:
+            retorder = {lp : None for lp in local_path}
+            cmds = []
+            remote_destination_dirs = ["/".join(rp.split("/")[:-1]) or "." for rp in remote_path]
+            for remote_destination_dir in set(remote_destination_dirs):
+                dir_local_paths = [lp for lp, rdd in zip(local_path, remote_destination_dirs) if rdd == remote_destination_dir]
+                dir_retval = self.mput(dir_local_paths, remote_destination_dir=remote_destination_dir, execute=execute, **kwargs)
+                if not execute:
+                    cmds.append(dir_retval)
+                    continue
+                for rv, lp in zip(dir_retval, dir_local_paths):
+                    retorder[lp] = rv
+            if not execute:
+                return cmds
+            retval = [retorder[lp] for lp in local_path]
+            return rettype(retval)
+        remote_path, local_path = remote_path[0], local_path[0]
+        kwargs.pop("P", None)
         exec_output = self.execute_command(
-            full_command, 
-            output=output, 
-            blocking=blocking,
-            execute=execute
+            f'put "{local_path}" -o "{remote_path}"',
+            execute=execute,
+            **kwargs
         )
         if not execute:
             return exec_output
+        pwd = self.pwd()
+        retval = [f'{pwd}/{rp}' for rp in remote_path]
+        if rettype == str:
+            if not len(retval) == 1:
+                raise RuntimeError(f'Expected one local destination, but got {len(retval)} instead.')
+            return retval[0]
+        return rettype(retval)
+    
+    def mput(
+        self,
+        local_paths : list[str] | tuple[str, ...],
+        remote_destination_dir : str,
+        execute : bool=True,
+        default_args : dict | None=None,
+        **kwargs
+        ):
+        default_args = default_args or {}
+        default_args = {"P" : 5, **default_args}
+        exec_output = self.execute_command(
+            "mput " + " ".join(local_paths),
+            execute=execute,
+            default_args=default_args,
+            O=remote_destination_dir,
+            **kwargs
+        )
+        if not execute:
+            return exec_output
+        pwd = self.pwd()
+        return [f'{pwd}/{os.path.basename(lp)}' for lp in local_paths]
+    
+    def rm(
+        self,
+        path : str | list[str] | tuple[str, ...],
+        force : bool=False,
+        execute : bool=True,
+        blocking : bool=True,
+        **kwargs
+        ) -> str | None:
+        """
+        Remove a file or directory.
+
+        Args:
+            path: File or directory to delete.
+            force: Force deletion of path (rm -rf), directories can only be deleted with this argument (empty or not).
+            **kwargs: Additional arguments passed to execute_command.
         
-        # Construct and return the absolute remote path
-        file_name = os.path.basename(os.path.abspath(local_path))
-        rpwd = self.pwd()
-        abs_remote_path = [rpwd + "/" + r for r in remote_destination]
-        return abs_remote_path
+        Returns:
+            The command `execute=False` else None
+        """
+        if isinstance(path, str):
+            path = [path]
+        args = {"r" : None, "f" : None}
+        if not force:
+            args.pop("r", None)
+            args.pop("f", None)
+        kwargs = {**kwargs, **args}
+        retval = self.execute_command('rm ' + ' & rm '.join(path), blocking=blocking, execute=execute, output=False, **kwargs)
+        if not execute:
+            return retval
+        
+    def du(
+        self,
+        path : str,
+        all : bool=False,
+        bytes : bool=True,
+        execute : bool=True,
+        blocking : bool=True,
+        default_args : dict | None=None,
+        **kwargs
+        ):
+        """
+        Get the size of a directory/path.
+
+        Args:
+            path: Path to examine.
+            all: Return size of all files and subdirectories of path, including path itself, separately.
+            bytes: Return size in bytes, otherwise in KB.
+            **kwargs: Passed to execute_command.
+        
+        Returns:
+            A dict with path(s) as keys and size as values, if `blocking=False` None and if `execute=False` the command.
+        """
+        default_args = default_args or {}
+        default_args = {"all" : None, "bytes" : None, **default_args}
+        if not all:
+            default_args.pop("all", None)
+        if not bytes:
+            default_args.pop("bytes", None)
+        retval = self.execute_command(f'du "{path}" | cat', blocking=blocking, execute=execute, default_args=default_args, **kwargs)
+        if not blocking:
+            return None
+        if not execute:
+            return retval
+        if not isinstance(retval, list):
+            raise RuntimeError(f'Unexpected return value: {retval}')
+        return dict(line.split("\t")[::-1] for line in retval)
 
     def ls(
             self, 
@@ -627,7 +920,7 @@ class ImplicitMount:
                     sanitize_path(output, path)
         # Non-recursive case
         else:
-            output = sanitize_path([], self.execute_command(f'cls "{path}" -1'))
+            output = sanitize_path([], self.execute_command(f'cls -1 "{path}"'))
         
         # Clear the progress bar if end of top-level
         if pbar and _top:
@@ -639,20 +932,25 @@ class ImplicitMount:
         
         return output
     
-    def lls(self, local_path: str = "", **kwargs) -> list[str]:
+    def lls(self, local_path: str = ".", **kwargs) -> list[str] | str | None:
         """List files in a local directory via the LFTP shell.
+
+        Args:
+            local_path: 
 
         Notes:
             Prefer native Python/OS listing. This is mainly useful for
             consistency and debugging through the same LFTP session.
         """
-        recursive = kwargs.get("R", kwargs.get("recursive", False))
+        if os.name != "posix":
+            raise NotImplementedError("IOHandler.lls() is not supported in non-Unix-like OSs (Windows)")
+        recursive = kwargs.pop("R", kwargs.pop("recursive", False))
         if not (recursive is False):
             if local_path == "":
                 local_path = "."
-            output = self.execute_command(f'!find "{local_path}" -type f -exec realpath --relative-to="{local_path}" {{}} \\;')
+            output = self.execute_command(f'!find "{local_path}" -type f -exec realpath --relative-to="{local_path}" {{}} \\; | cat', **kwargs)
         else: 
-            output = self.execute_command(f'!ls "{local_path}"', **kwargs)
+            output = self.execute_command(f'!ls "{local_path}" | cat', **kwargs)
         
         # Check if the output is a list
         if not isinstance(output, list):
@@ -691,44 +989,58 @@ class ImplicitMount:
             return output[0]
         else:
             raise TypeError("Expected list of length 1, got {}: {}".format(type(output), output))
-    
-    def _get_current_files(self, dir_path : str) -> list[str]:
-        return self.lls(dir_path, R="")
 
     def mirror(
             self, 
-            remote_path : str,
-            local_destination : str, 
+            remote : str,
+            local : str,
+            reverse : bool=False,
+            output : bool=True,
             blocking : bool=True,
             execute : bool=True,
-            do_return : bool=True,
+            default_args : dict | None=None,
             **kwargs
         ) -> list[str] | None:
         """Mirror a remote directory to a local destination (LFTP ``mirror``).
 
         Args:
-            remote_path: Remote directory to download.
-            local_destination: Local destination directory.
-            blocking: If True, wait for completion.
-            execute: If False, return the command string.
-            do_return: If True, return the newly downloaded files.
+            remote: Remote directory to download (if not reverse).
+            local: Local destination directory (if not reverse).
+            reverse: Upload from `local` to `destination`.
             **kwargs: Additional options forwarded to ``mirror``.
 
         Returns:
-           List of newly downloaded files if ``do_return`` is True, otherwise None. 
-           If ``execute`` is False, returns the command string.
+           List of newly downloaded files or following `ImplicitMount.execute_command`.
         """
-        if do_return:
+        if "R" in kwargs:
+            raise RuntimeError(f'Passing `R` to IOHandler.mirror is not supported, please use `reverse` instead.')
+        if reverse:
+            kwargs["R"] = None
+            if remote is None:
+                remote = self.pwd()
+            if local is None:
+                raise ValueError('When reverse mirroring (uploading) local source must be specified.')
+        else:
+            if local is None:
+                local = self.lpwd()
+            if reverse is None:
+                raise ValueError('When mirroring (downloading) remote source must be specified.')
+        if output:
+            print(f'{remote=} {local=} {reverse=}')
             # Capture the state of the directory before the operation
-            pre_existing_files = self._get_current_files(local_destination)
+            if reverse:
+                pre_existing_files = [] if not self.exists(remote) else self.ls(remote)
+            else:
+                pre_existing_files = [] if not os.path.exists(local) else self.lls(local, recursive=True)
             # Ensure that the pre_existing_files list is unique
             pre_existing_files = set(pre_existing_files)
 
         # Execute the mirror command
-        default_args = {'P': 5, 'use-cache': None}
+        default_args = default_args or {}
+        default_args = {'P': 5, 'use-cache': None, **default_args}
         exec_output = self.execute_command(
-            f'mirror "{remote_path}" "{local_destination}"', 
-            output=blocking, 
+            f'mirror "{local}" "{remote}"' if reverse else f'mirror "{remote}" "{local}"', 
+            output=False, 
             blocking=blocking, 
             execute=execute,
             default_args=default_args, 
@@ -737,18 +1049,17 @@ class ImplicitMount:
         if not execute:
             return exec_output
         
-        if do_return:
+        if output:
             # Capture the state of the directory after the operation
-            post_download_files = self._get_current_files(local_destination)
+            if reverse:
+                post_download_files = [] if not self.exists(remote) else self.ls(remote)
+            else:
+                post_download_files = [] if not os.path.exists(local) else self.lls(local, recursive=True)
             # Ensure that the post_download_files list is unique
             post_download_files = set(post_download_files)
-
             # Calculate the set difference to get the newly downloaded files
             new_files = post_download_files - pre_existing_files
-            
             return list(new_files)
-        else:
-            return None
 
 class IOHandler(ImplicitMount):
     """
@@ -798,7 +1109,7 @@ class IOHandler(ImplicitMount):
             **kwargs
         )
         if local_dir is None or local_dir == "":
-            if self.default_config['local_dir'] is None or self.default_config['local_dir'] == "":
+            if self.default_config["local_dir"] is None or self.default_config['local_dir'] == "":
                 local_dir = tempfile.TemporaryDirectory().name
             else:
                 local_dir = self.default_config['local_dir']
@@ -810,8 +1121,6 @@ class IOHandler(ImplicitMount):
         self.user_confirmation = user_confirmation
         self.do_clean = clean
         self.lftp_settings = lftp_settings
-        self.last_download = None
-        self.last_type = None
         self.cache : dict[str, list[str]] = {}
 
     def lcd(self, local_path : str):
@@ -819,7 +1128,7 @@ class IOHandler(ImplicitMount):
         super().lcd(self.local_dir)
 
     def lpwd(self):
-        raise TypeError("'lpwd()' should not be used for 'IOHandler' objects, use the 'local_dir' attribute instead.")
+        main_logger.info("'lpwd()' should not be used for 'IOHandler' objects, use the 'local_dir' attribute instead.")
 
     def __enter__(self) -> "IOHandler":
         """
@@ -864,156 +1173,93 @@ class IOHandler(ImplicitMount):
             self, 
             remote_path : str | list[str] | tuple[str, ...],
             local_destination : str | list[str] | tuple[str, ...] | None=None,
+            n : int=15,
             blocking : bool=True,
             **kwargs
-        ) -> str | list[str]:
+        ):
         """
         Downloads one or more files or a directory from the remote directory to the given local destination.
 
         Args:
             remote_path: The remote path(s) to download.
             local_destination: The local destination(s) to download the file(s) to. If None, the file(s) will be downloaded to the current local directory.
+            n: Parallel connections to use if relevant (default=15).
             blocking: If True, the function will block until the download is complete.
             **kwargs: Extra keyword arguments are passed to the IOHandler.multi_download, IOHandler.pget or IOHandler.mirror functions depending on the type of the remote path(s).
 
         Returns:
-           The local path of the downloaded file(s) or directory.
+           The local path(s) of the downloaded file(s) or directory.
         """
-        if len(remote_path) == 0:
-            raise ValueError(f'Downloading zero-length source is not valid: {remote_path=}')
-        # If multiple remote paths are specified, use multi_download instead of download, 
-        # this function is more flexible than mirror (works for files from different directories) and much faster than executing multiple pget commands
-        if not isinstance(remote_path, str) and len(remote_path) > 1:
-            if isinstance(local_destination, (list, tuple)) and len(set(local_destination)) == 1:
-                local_destination = local_destination[0]
-            if not isinstance(local_destination, (list, tuple)):
-                return self._multi_download(remote_path, local_destination, **kwargs)
+        if isinstance(remote_path, str):
+            match self.pathtype(remote_path):
+                case RemoteType.MISSING:
+                    raise RuntimeError("Missing download target: " + remote_path)
+                case RemoteType.DIRECTORY:
+                    if not (isinstance(local_destination, str) or local_destination is None):
+                        raise ValueError("Downloading directories should have a single destination!")
+                    return self.mirror(remote_path, local_destination, blocking=blocking, P=n, **kwargs)
+                case RemoteType.FILE:
+                    return self.pget(remote_path, local_destination, blocking=blocking, n=n, **kwargs)
+                case _:
+                    raise RuntimeError('Remote download path exists, but is not a file or directory?')
+        n = min(len(remote_path), n)
+        return self.get(remote_path, local_destination, blocking=blocking, P=n, **kwargs)
 
-            # If there are multiple local destinations, split into separate subcalls
-            if len(remote_path) != len(local_destination):
-                raise ValueError(f'When supplying multiple local destionations, they are expected to match 1-1 with remote paths. Got {len(remote_path)=} != {len(local_destination)=}')
-            result = [None for _ in range(len(remote_path))]
-            reindex = {rp : i for i, rp in enumerate(remote_path)}
-            if len(reindex) != len(remote_path):
-                raise ValueError("Duplicate remote paths supplied.")
-            for this_ldir in set(local_destination):
-                this_ldir_paths = [rp for rp, ld in zip(remote_path, local_destination) if ld == this_ldir]
-                if len(this_ldir_paths) == 0:
-                    continue
-                for rp, lp in zip(this_ldir_paths, self._multi_download(this_ldir_paths, this_ldir, **kwargs)):
-                    result[reindex[rp]] = lp
-            if any(map(lambda x : x is None, result)):
-                raise RuntimeError("One or more files failed to download.")
-            return result
-        
-        if not isinstance(remote_path, str) and len(remote_path) == 1:
-            remote_path = remote_path[0]
-        if not isinstance(remote_path, str):
-            raise TypeError("Expected str, got {}".format(type(remote_path)))
-        
-        if local_destination is None:
-            local_destination = self.local_dir
-        assert isinstance(local_destination, str)
-
-        # Check if remote and local have file extensions:
-        # The function assumes files have extensions and directories do not.
-        remote_has_ext, local_has_ext = os.path.splitext(remote_path)[1] != "", os.path.splitext(local_destination)[1] != ""
-        # If both remote and local have file extensions, the local destination should be a file path.
-        if remote_has_ext and local_has_ext and os.path.isdir(local_destination):
-            raise ValueError("Destination must be a file path if both remote and local have file extensions.")
-        # If the remote does not have a file extension, the local destination should be a directory.
-        if not remote_has_ext and not os.path.isdir(local_destination):
-            raise ValueError("Destination must be a directory if remote does not have a file extension.")
-        
-        if not os.path.exists(local_destination):
-            os.makedirs(local_destination, exist_ok=True)
-        
-        # Download cases;
-        # If the remote is a single file, use pget.
-        if remote_has_ext:
-            local_result = self.pget(remote_path, local_destination, blocking, **kwargs)
-            self.last_type = "file"
-        # Otherwise use mirror.
-        else:
-            local_result = self.mirror(remote_path, local_destination, blocking, **kwargs)
-            self.last_type = "directory"
-        
-        # TODO: Check local_result == local_destination (if it can be done in a relatively efficient way)
-        
-        # Store the last download for later use (nice for debugging)
-        self.last_download = local_result
-        # Return the local path of the downloaded file or directory
-        return local_result
-    
-    def _multi_download(
+    def upload(
             self, 
-            remote_paths : list[str] | tuple[str, ...],
-            local_destination : str | None,
+            local_path : str | list[str] | tuple[str, ...],
+            remote_destination : str | list[str] | tuple[str, ...] | None=None,
+            n : int=15,
             blocking : bool=True,
-            n : int=15, 
             **kwargs
-        ) -> list[str]:
+        ):
         """
-        Downloads a list of files from the remote directory to the given local destination.
+        Downloads one or more files or a directory from the remote directory to the given local destination.
 
         Args:
-            remote_paths: A list of remote paths to download.
-            local_destination: The local destination to download the files to. If None, the files will be downloaded to the current local directory.
+            local_path: The local file(s) or directory to upload.
+            remote_destination: The destination of uploaded files. If None will upload to current remote directory.
+            n: Parallel connections to use if relevant (default=15).
             blocking: If True, the function will block until the download is complete.
-            n: Number of files to download in parallel.
-            **kwargs: Extra keyword arguments are ignored.
-        
+            **kwargs: Extra keyword arguments are passed to the IOHandler.multi_download, IOHandler.pget or IOHandler.mirror functions depending on the type of the remote path(s).
+
         Returns:
-           A list of the local paths of the downloaded files.
+           The local path(s) of the downloaded file(s) or directory.
         """
-        # TODO: This function should really wrap an IOHandler.mget function, which should be implemented in the ImplicitMount class
-        # Type checking and default argument configuration
-        if not isinstance(remote_paths, (list, tuple)):
-            raise TypeError("Expected list or tuple, got {}".format(type(remote_paths)))
-        if len(remote_paths) == 0:
-            raise ValueError("Expected non-empty list or tuple for `remote_paths`, got {}".format(remote_paths))
-        if not (isinstance(local_destination, str) or local_destination is None):
-            raise TypeError("Expected str or None, got {}".format(type(local_destination)))
-        if local_destination is None:
-            local_destination = self.local_dir
-        local_files = [os.path.join(local_destination, os.path.basename(r)) for r in remote_paths]
-        if any(map(os.path.exists, local_files)):
-            while os.path.exists(subdir := os.path.join(local_destination, str(uuid.uuid4()))):
-                continue
-            return self._multi_download(remote_paths, subdir, blocking=blocking, n=n, **kwargs)
-        os.makedirs(local_destination, exist_ok=True)
-
-        # Assemble the mget command, options and arguments
-        multi_command = f'mget -O "{local_destination}" -P {max(1, min(n, len(remote_paths)))} ' + ' '.join([f'"{r}"' for r in remote_paths])
-        # Execute the mget command
-        self.execute_command(multi_command, output=blocking, blocking=blocking)
-        
-        # Check if the files were downloaded TODO: is this too slow? Should we just assume that the files were downloaded for efficiency?
-        missing_files = [l for l in local_files if not os.path.exists(l)]
-        if missing_files:
-            raise RuntimeError(f"Failed to download files {missing_files}")
-
-        # Store the last download for later use (nice for debugging)
-        self.last_download = local_destination
-        self.last_type = "multi"
-        
-        # Return the local paths of the downloaded files
-        return local_files
+        if isinstance(local_path, str):
+            if not os.path.exists(local_path):
+                raise RuntimeError("Missing download target: " + local_path)
+            if os.path.isdir(local_path):
+                if not (isinstance(remote_destination, str) or remote_destination is None):
+                    raise ValueError("Uploading directories should have a single destination!")
+                return self.mirror(remote_destination, local_path, reverse=True, blocking=blocking, P=n, **kwargs)
+            if os.path.isfile(local_path):
+                return self.put(local_path, remote_destination, blocking=blocking, **kwargs)
+            raise RuntimeError('Local upload path exists, but is not a file or directory?')
+        n = min(len(local_path), n)
+        return self.put(local_path, remote_destination, blocking=blocking, P=n, **kwargs)
 
     def sync(
             self, 
-            local_destination : str | None=None, 
+            local_destination : str | None=None,
+            direction : str="down",
+            allow_root : bool=False,
             progress : bool=False,
             batch_size : int=128,
             replace_local : bool=False,
             refresh_cache : bool=False,
             **kwargs
-        ) -> list[str]:
+        ):
         """
         Synchronized the current remote directory to the given local destination.
 
         Args:
-            local_destination: The local destination to synchronize the current remote directory to.
+            local_destination: The local destination to synchronize the current remote directory to, defaults to "<CURRENT_LOCAL_DIRECTORY_PATH>/<CURRENT_REMOTE_DIRECTORY_NAME>".
+                OBS: If the current remote directory is root, then <CURRENT_REMOTE_DIRECTORY_NAME> is replaced with "ROOT".
+            direction: Synchronization directory; one of non-case-sensitive ["down", "up", "both"] (default="down"). 
+                "down": Download contents of current remote directory to local destination.
+                "up": Upload contents of local destination to current remote directory.
+                "both": First synchronize "down", then synchronize "up".
             progress: Show a progress bar.
             batch_size: Number of files passed to each download call.
             replace_local: By default existing files are skipped, if this is enabled, existing files are deleted and refetched.
@@ -1026,8 +1272,13 @@ class IOHandler(ImplicitMount):
         if not isinstance(local_destination, str) and local_destination is not None:
             raise TypeError("Expected str or None, got {}".format(type(local_destination)))
         if local_destination is None:
-            local_destination = self.local_dir
-        local_destination = os.path.abspath(os.path.join(local_destination, self.pwd().split("/")[-1]))
+            cur_remote_dir = self.pwd().split("/")[-1]
+            if cur_remote_dir == "" and not allow_root:
+                raise RuntimeError(f'Attempted to synchronize root of remote, but `{allow_root=}`!')
+            local_destination = os.path.join(self.lpwd(), cur_remote_dir or "ROOT")
+        local_destination = os.path.normpath(os.path.abspath(os.path.expandvars(os.path.expanduser(local_destination))))
+        if os.path.dirname(local_destination) == local_destination and not allow_root:
+            raise RuntimeError(f'Attempted to synchronize root of local, but {allow_root=}!')
         if not os.path.exists(local_destination):
             try:
                 os.makedirs(local_destination)
@@ -1035,23 +1286,43 @@ class IOHandler(ImplicitMount):
                 pass
         if self.pwd() not in self.cache:
             self.cache_file_index(override=refresh_cache)
-        files = self.cache[self.pwd()]
-        ldest = [os.path.join(local_destination, *f.split("/")) for f in files]
-        ldest, files = zip(*sorted([(l, f) for l, f in zip(ldest, files) if replace_local or not os.path.exists(l)]))
-        ldir = [os.path.dirname(dst) for dst in ldest]
-        for bi in trange(-(-len(files)//batch_size), desc=f"Synchronizing: ({self.pwd()}) ==> ({local_destination}) ...", unit="file", unit_scale=batch_size, disable=not progress, dynamic_ncols=True):
-            bs, be = bi*batch_size, min((bi+1)*batch_size, len(files))
-            if replace_local:
-                for ld in ldest[bs:be]:
-                    if os.path.exists(ld):
-                        os.remove(ld)
-            lres = self.download(files[bs:be], ldir[bs:be], **kwargs)
-            if isinstance(lres, str):
-                lres = [lres]
-            for r, e, f in zip(lres, ldest[bs:be], files[bs:be]):
-                if r != e:
-                    raise RuntimeError(f'Unexpected download location for {f}, expected {e}, but got {r}?!')
-        return list(ldest)
+        down_files = []
+        if direction in ["down", "both"]:
+            down_files = self.cache[self.pwd()]
+            ldest = [os.path.join(local_destination, *f.split("/")) for f in down_files]
+            ldest, down_files = zip(*sorted([(l, f) for l, f in zip(ldest, down_files) if replace_local or not os.path.exists(l)]))
+            down_files : list[str]
+            ldir = [os.path.dirname(dst) for dst in ldest]
+            for bi in trange(-(-len(down_files)//batch_size), desc=f"Synchronizing down: ({self.pwd()}) ==> ({local_destination}) ...", unit="file", unit_scale=batch_size, disable=not progress, dynamic_ncols=True):
+                bs, be = bi*batch_size, min((bi+1)*batch_size, len(down_files))
+                if replace_local:
+                    for ld in ldest[bs:be]:
+                        if os.path.exists(ld):
+                            os.remove(ld)
+                lres = self.download(down_files[bs:be], ldir[bs:be], **kwargs)
+                if isinstance(lres, str):
+                    lres = [lres]
+                for r, e, f in zip(lres, ldest[bs:be], down_files[bs:be]):
+                    if r != e:
+                        raise RuntimeError(f'Unexpected download location for {f}, expected {e}, but got {r}?!')
+        up_files = []
+        if direction in ["up", "both"]:
+            up_files = self.lls(local_destination)
+            if not isinstance(up_files, list):
+                raise RuntimeError(f'Unexpected return value: {up_files}')
+            skippers = set([os.path.join(f.split("/")) for f in down_files])
+            up_files = [f for f in up_files if f not in skippers]
+            rdest = [f'{self.pwd()}/{f}' for f in up_files]
+            rdir = ["/".join(f.split("/")[:-1]) for f in rdest]
+            for bi in trange(-(-len(down_files)//batch_size), desc=f"Synchronizing up: ({self.pwd()}) ==> ({local_destination}) ...", unit="file", unit_scale=batch_size, disable=not progress, dynamic_ncols=True):
+                bs, be = bi*batch_size, min((bi+1)*batch_size, len(down_files))
+                rres = self.upload(up_files[bs:be], rdir[bs:be], **kwargs)
+                if isinstance(rres, str):
+                    rres = [rres]
+                for r, e, f in zip(rres, rdest[bs:be], up_files[bs:be]):
+                    if r != e:
+                        raise RuntimeError(f'Unexpected upload location for {f}, expected {e}, but got {r}?!')
+        return list(set(down_files).union(set(up_files)))
     
     def get_file_index(
             self, 
@@ -1076,16 +1347,10 @@ class IOHandler(ImplicitMount):
         if override and not store:
             raise ValueError("override cannot be 'True' if store is 'False'!")
         # Check if file index exists
-        glob_result = self.execute_command('glob -f --exist .*folder_index.txt && echo "YES" || echo "NO"')
-        if isinstance(glob_result, list) and len(glob_result) == 1:
-            glob_result = glob_result[0]
-        file_index_exists = glob_result == "YES"
+        file_index_exists = self.exists(".folder_index.txt")
         if not file_index_exists:
             # Backwards compatibility check for folder index with old naming convention (non-hidden)
-            bc_glob_result = self.execute_command('glob -f --exist *folder_index.txt && echo "YES" || echo "NO"')
-            if isinstance(bc_glob_result, list) and len(bc_glob_result) == 1:
-                bc_glob_result = bc_glob_result[0]
-            bc_file_index_exists = bc_glob_result == "YES"
+            bc_file_index_exists = self.exists("folder_index.txt")
             if bc_file_index_exists:
                 bc_file_index = self.execute_command('glob -f du -sh *folder_index.txt | sort -hr | cut -f 2 | head -n 1')
                 if not (isinstance(bc_file_index, list) and len(bc_file_index) == 1 and isinstance(bc_file_index := bc_file_index[0], str)):
@@ -1113,7 +1378,7 @@ class IOHandler(ImplicitMount):
             # Store the file index on the remote if 'store' is True, otherwise delete it
             if store:
                 # Self has an implicit reference to the local working directory, however the scripts does not necessarily have the same working directory
-                self.put(".folder_index.txt")
+                self.upload(".folder_index.txt")
                 os.remove(local_index_path)
         
         # Download the file index if 'store' is True or it already exists on the remote, otherwise read it from the local directory
@@ -1175,7 +1440,7 @@ class IOHandler(ImplicitMount):
                     main_logger.error("\t" + "\n\t".join(files_in_dir))
             raise e
 
-class RemotePathIterator:# 
+class RemotePathIterator:
     """Buffered iterator for streaming many remote files efficiently.
 
     Downloads are performed in a background thread and yielded as

--- a/src/pyremotedata/implicit_mount.py
+++ b/src/pyremotedata/implicit_mount.py
@@ -1026,7 +1026,6 @@ class ImplicitMount:
             if reverse is None:
                 raise ValueError('When mirroring (downloading) remote source must be specified.')
         if output:
-            print(f'{remote=} {local=} {reverse=}')
             # Capture the state of the directory before the operation
             if reverse:
                 pre_existing_files = [] if not self.exists(remote) else self.ls(remote)
@@ -1173,7 +1172,7 @@ class IOHandler(ImplicitMount):
             self, 
             remote_path : str | list[str] | tuple[str, ...],
             local_destination : str | list[str] | tuple[str, ...] | None=None,
-            n : int=15,
+            n : int=14,
             blocking : bool=True,
             **kwargs
         ):
@@ -1183,7 +1182,7 @@ class IOHandler(ImplicitMount):
         Args:
             remote_path: The remote path(s) to download.
             local_destination: The local destination(s) to download the file(s) to. If None, the file(s) will be downloaded to the current local directory.
-            n: Parallel connections to use if relevant (default=15).
+            n: Parallel connections to use if relevant (default=14).
             blocking: If True, the function will block until the download is complete.
             **kwargs: Extra keyword arguments are passed to the IOHandler.multi_download, IOHandler.pget or IOHandler.mirror functions depending on the type of the remote path(s).
 
@@ -1209,7 +1208,7 @@ class IOHandler(ImplicitMount):
             self, 
             local_path : str | list[str] | tuple[str, ...],
             remote_destination : str | list[str] | tuple[str, ...] | None=None,
-            n : int=15,
+            n : int=14,
             blocking : bool=True,
             **kwargs
         ):
@@ -1219,7 +1218,7 @@ class IOHandler(ImplicitMount):
         Args:
             local_path: The local file(s) or directory to upload.
             remote_destination: The destination of uploaded files. If None will upload to current remote directory.
-            n: Parallel connections to use if relevant (default=15).
+            n: Parallel connections to use if relevant (default=14).
             blocking: If True, the function will block until the download is complete.
             **kwargs: Extra keyword arguments are passed to the IOHandler.multi_download, IOHandler.pget or IOHandler.mirror functions depending on the type of the remote path(s).
 

--- a/src/pyremotedata/implicit_mount.py
+++ b/src/pyremotedata/implicit_mount.py
@@ -1355,7 +1355,7 @@ class IOHandler(ImplicitMount):
             main_logger.debug("Creating folder index...")
             # Traverse the remote directory and write the file index to a file
             files = self.ls(recursive=True, use_cache=False, pbar=True)
-            local_index_path = os.path.join(self.local_dir, ".folder_index.txt")
+            local_index_path = os.path.join(self.lpwd(), ".folder_index.txt")
             with open(local_index_path, "w") as f:
                 for file in files:
                     f.write(file + "\n")
@@ -1399,25 +1399,25 @@ class IOHandler(ImplicitMount):
     def clean(self):
         if self.user_confirmation:
             # Ask for confirmation
-            confirmation = input(f"Are you sure you want to delete all files in the current directory {self.local_dir}? (y/n)")
+            confirmation = input(f"Are you sure you want to delete all files in the current directory {self.lpwd()}? (y/n)")
             if confirmation.lower() != "y":
                 main_logger.debug("Aborted")
                 return
 
         main_logger.debug("Cleaning up...")
-        for path in os.listdir(self.local_dir):
+        for path in os.listdir(self.lpwd()):
             try:
                 delete_file_or_dir(path)
             except Exception as e:
                 main_logger.debug(f"Error while deleting {path}: {e}")
         try:
-            shutil.rmtree(self.local_dir)
+            shutil.rmtree(self.lpwd())
         except Exception as e:
             main_logger.error("Error while cleaning local backend directory!")
-            files_in_dir = os.listdir(self.local_dir)
+            files_in_dir = os.listdir(self.lpwd())
             if files_in_dir:
                 n_files = len(files_in_dir)
-                main_logger.error(f"{n_files} files in local directory ({self.local_dir}):")
+                main_logger.error(f"{n_files} files in local directory ({self.lpwd()}):")
                 if n_files > 5:
                     main_logger.error("\t" + "\n\t".join(files_in_dir[:5]) + "\n\t...")
                 else:
@@ -1473,7 +1473,7 @@ class RemotePathIterator:
                 main_logger.warning(f'Using cached file index. [{", ".join(kwargs.keys())}] will be ignored.')
             self.remote_paths = self.io_handler.cache[self.io_handler.pwd()]
         self.remote_paths = list(self.remote_paths) # Ensure locality
-        self.temp_dir = self.io_handler.local_dir
+        self.temp_dir = self.io_handler.lpwd()
         self.batch_size = batch_size
         self.batch_parallel = batch_parallel
         self.max_queued_batches = max_queued_batches

--- a/src/pyremotedata/implicit_mount.py
+++ b/src/pyremotedata/implicit_mount.py
@@ -1227,7 +1227,7 @@ class IOHandler(ImplicitMount):
         """
         if isinstance(local_path, str):
             if not os.path.exists(local_path):
-                raise RuntimeError("Missing download target: " + local_path)
+                raise RuntimeError("Missing upload target: " + local_path)
             if os.path.isdir(local_path):
                 if not (isinstance(remote_destination, str) or remote_destination is None):
                     raise ValueError("Uploading directories should have a single destination!")
@@ -1377,7 +1377,7 @@ class IOHandler(ImplicitMount):
             # Store the file index on the remote if 'store' is True, otherwise delete it
             if store:
                 # Self has an implicit reference to the local working directory, however the scripts does not necessarily have the same working directory
-                self.upload(".folder_index.txt")
+                self.upload(local_index_path)
                 os.remove(local_index_path)
         
         # Download the file index if 'store' is True or it already exists on the remote, otherwise read it from the local directory

--- a/src/pyremotedata/implicit_mount.py
+++ b/src/pyremotedata/implicit_mount.py
@@ -603,13 +603,10 @@ class ImplicitMount:
         )
         if not execute:
             return exec_output
-        lpwd = self.lpwd()
-        retval = [f'{lpwd}/{lp}' for lp in local_path]
-        if rettype == str:
-            if not len(retval) == 1:
-                raise RuntimeError(f'Expected one local destination, but got {len(retval)} instead.')
-            return retval[0]
-        return rettype(retval)
+        retval = f'{self.lpwd()}/{local_path}'
+        if rettype != str:
+            return rettype([retval])
+        return retval
     
     def mget(
         self,
@@ -746,13 +743,10 @@ class ImplicitMount:
         )
         if not execute:
             return exec_output
-        pwd = self.pwd()
-        retval = [f'{pwd}/{rp}' for rp in remote_path]
-        if rettype == str:
-            if not len(retval) == 1:
-                raise RuntimeError(f'Expected one local destination, but got {len(retval)} instead.')
-            return retval[0]
-        return rettype(retval)
+        retval = f'{self.pwd()}/{remote_path}'
+        if rettype != str:
+            return rettype([retval])
+        return retval
     
     def mput(
         self,

--- a/src/pyremotedata/implicit_mount.py
+++ b/src/pyremotedata/implicit_mount.py
@@ -1028,7 +1028,7 @@ class ImplicitMount:
         if output:
             # Capture the state of the directory before the operation
             if reverse:
-                pre_existing_files = [] if not self.exists(remote) else self.ls(remote)
+                pre_existing_files = [] if not self.exists(remote) else self.ls(remote, recursive=True)
             else:
                 pre_existing_files = [] if not os.path.exists(local) else self.lls(local, recursive=True)
             # Ensure that the pre_existing_files list is unique
@@ -1051,7 +1051,7 @@ class ImplicitMount:
         if output:
             # Capture the state of the directory after the operation
             if reverse:
-                post_download_files = [] if not self.exists(remote) else self.ls(remote)
+                post_download_files = [] if not self.exists(remote) else self.ls(remote, recursive=True)
             else:
                 post_download_files = [] if not os.path.exists(local) else self.lls(local, recursive=True)
             # Ensure that the post_download_files list is unique

--- a/tests/test_transfer.py
+++ b/tests/test_transfer.py
@@ -87,7 +87,7 @@ class TestUploadDownload(unittest.TestCase):
                 # Upload a test file to the mock SFTP server
                 test_file_size = 10 # MB
                 n_rep = 10
-                generate_test_file_command = f"bash -c 'openssl rand -out {os.path.join(handler.local_dir, 'localfile.txt')} -base64 {int(test_file_size * (10**6) * 3/4)}'"
+                generate_test_file_command = f"bash -c 'openssl rand -out {os.path.join(handler.lpwd(), 'localfile.txt')} -base64 {int(test_file_size * (10**6) * 3/4)}'"
                 module_logger.info(f'Generating test file with command: {generate_test_file_command}')
                 os.system(generate_test_file_command)
                 start_upload = time.time()
@@ -100,7 +100,7 @@ class TestUploadDownload(unittest.TestCase):
                 download_result = handler.execute_command(f'repeat -c {n_rep} -d 0.01 "(!rm -f testfile.txt) && {download_result}"')
                 end_download = time.time()
                 # Get the local directory where the file should be downloaded to
-                local_directory = handler.local_dir
+                local_directory = handler.lpwd()
                 # Sanity checks
                 local_file_exists = os.path.exists(os.path.join(local_directory, 'testfile.txt'))
                 local_file_size = os.path.getsize(os.path.join(local_directory, 'testfile.txt')) / 10**6
@@ -111,8 +111,8 @@ class TestUploadDownload(unittest.TestCase):
                     raise RuntimeError(f"Something went wrong with the download. The file size (~{local_file_size:.2f} MB) is not correct.")
             
                 # Cleanup
-                os.remove(os.path.join(handler.local_dir, "localfile.txt"))
-                os.remove(os.path.join(handler.local_dir, "testfile.txt"))
+                os.remove(os.path.join(handler.lpwd(), "localfile.txt"))
+                os.remove(os.path.join(handler.lpwd(), "testfile.txt"))
             
             from pyremotedata.config import remove_config
             remove_config()


### PR DESCRIPTION
Changes:

1. Allow using `user` and `password` with SSH-less SFTP connection via password ala ERDA Sharelink IDs: _It is now possible to completely avoid any SSH or environment setup by passing both `user` and `password` to `ImplicitMount` or `IOHandler`.
2. Better upload/download interface with `IOHandler.download`/`IOHandler.upload`.
3. Synchronization feature completed: _More testing needed, but seems to work_
4. More `lftp` functionality introduced, `ImplicitMount` now:
    - supports `du`, `rm`, `get`, `put`, `mget` and `mput`
    - properly handles `mirror -R` (reverse)
    - has two new functions `exists` check if a file/directory exists on remote and `pathtype` returns an enum for a path with possible values "MISSING", "FILE" and "DIRECTORY", allowing much easier check for files and type